### PR TITLE
Move sharp to a peer dependency; Coerce numeric config values

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 There is also [sharp-loader](https://www.npmjs.com/package/sharp-loader), but I needed a loader which allows access to the entire [Sharp API](http://sharp.dimens.io/en/stable/), and would return a (one) image instead of a (responsive) set. This also allows subsequent loaders (e.g. [image-webpack-loader](https://www.npmjs.com/package/image-webpack-loader)) to execute succesfully.
 
 ## Install
-`$ npm install sharp-image-loader`
+`$ npm install sharp sharp-image-loader`
 
 ## Options
 ```js

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ const numericOptions = [
   'tiffXres',
   'tiffYres',
   'tileSize',
-  'tileOverlap',
+  'tileOverlap'
 ];
 
 // Exports.
@@ -94,7 +94,7 @@ module.exports = function (source, map) {
     if (numericOptions.includes(key)) {
       config[key] = Number(value);
     }
-  })
+  });
 
   // Transform the source.
   const transformer = sharp(source);

--- a/index.js
+++ b/index.js
@@ -30,6 +30,50 @@
 const loaderUtils = require('loader-utils');
 const sharp = require('sharp');
 
+const numericOptions = [
+  'limitInputPixels',
+  'topOffsetPre',
+  'topOffsetPre',
+  'leftOffsetPre',
+  'widthPre',
+  'heightPre',
+  'topOffsetPost',
+  'leftOffsetPost',
+  'widthPost',
+  'heightPost',
+  'width',
+  'height',
+  'canvas',
+  'crop',
+  'angle',
+  'extendTop',
+  'extendBottom',
+  'extendLeft',
+  'extendRight',
+  'blurSigma',
+  'sharpenSigma',
+  'sharpenFlat',
+  'sharpenJagged',
+  'threshold',
+  'trimTolerance',
+  'gamma',
+  'normalise',
+  'extractChannel',
+  'overlayGravity',
+  'overlayXOffset',
+  'overlayYOffset',
+  'withMetadataOrientation',
+  'jpegQuality',
+  'pngCompressionLevel',
+  'webpQuality',
+  'webpAlphaQuality',
+  'tiffQuality',
+  'tiffXres',
+  'tiffYres',
+  'tileSize',
+  'tileOverlap',
+];
+
 // Exports.
 module.exports = function (source, map) {
   // Extract.
@@ -45,6 +89,12 @@ module.exports = function (source, map) {
     const resourceConfig = loaderUtils.getOptions({ query: context.resourceQuery });
     config = Object.assign({ }, config, resourceConfig);
   }
+
+  Object.entries(config).forEach(([key, value]) => {
+    if (numericOptions.includes(key)) {
+      config[key] = Number(value);
+    }
+  })
 
   // Transform the source.
   const transformer = sharp(source);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name"        : "sharp-image-loader",
-  "version"     : "0.1.0-alpha.2",
+  "version"     : "0.1.0-alpha.3",
   "description" : "Sharp image loader module for webpack.",
   "keywords"    : [ "webpack", "loader", "module", "sharp", "images" ],
   "homepage"    : "https://github.com/vseventer/sharp-image-loader",
@@ -13,8 +13,10 @@
     "pretest" : "semistandard | snazzy"
   },
   "dependencies": {
-    "loader-utils" : "1.1.x",
-    "sharp"        : "0.18.x"
+    "loader-utils" : "1.1.x"
+  },
+  "peerDependencies": {
+    "sharp": "0.x.x"
   },
   "devDependencies": {
     "semistandard" : "11.0.x",


### PR DESCRIPTION
Hi there,

I came across this loader after nearly giving up with sane image optimisation through webpack. I like the simple interface between webpack and Sharp that this provides.

As it's been a few years since the last update to the code, the version of sharp used is pretty out of date as noted in #3. One of the suggestions in #3 was to move `sharp` to a peer dependency so any version could be used with the loader without you needing to update the package. I've gone ahead and set this up in this PR. I've constrained it to a sub v1 release as the way the loader applies options may change between major releases, so it'd be safer to update the peer dependency constraint at that point.

The other addition I've made is coercion of numeric option values passed from webpack. I ran into a bug where using the resource query loader style (as in example 2 of the readme) would pass options such as `width` as a string, causing Sharp to throw an exception for. This change ensures all options which should be numeric will be coerced to a number, anything resolved to `NaN` will get a clearer exception from Sharp and resource queries will work as expected. Similar coercion may be required for other non-string types but I've not tested this.

Let me know if there are any problems with this or additional changes that need to be made. If you'd prefer not to accept this PR, no worries at all but in that case I may need to publish my fork to an alternate NPM package (with proper credit to you of course) so I can continue to use the loader!

Cheers!

Fixes #3 